### PR TITLE
Localize plugin and refine note styling

### DIFF
--- a/assets/css/highlighter.css
+++ b/assets/css/highlighter.css
@@ -1,27 +1,25 @@
-/* Badge pequeño al lado del mark cuando hay nota */
+/* Badge displayed next to highlighted text when a note exists */
 .hl-note-dot {
     display: inline-block;
     width: 10px;
     height: 10px;
     margin-left: 4px;
     border-radius: 2px;
-    border: 1px solid rgba(0,0,0,0.2);
-    background: #111;
     cursor: pointer;
     vertical-align: middle;
     transform: translateY(-1px);
   }
   
-  /* Popover de nota */
+  /* Note popover container */
   #politeia-hl-note-popover {
     position: absolute;
     display: none;
     z-index: 100000;
   }
   #politeia-hl-note-popover .note-content {
-    background: #fff;
-    border: 1px solid #e5e5e5;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+    border: none;
+    box-shadow: none;
+    background: none;
     border-radius: 10px;
     padding: 12px;
     width: 320px;
@@ -40,10 +38,20 @@
   }
   #politeia-hl-note-popover .actions button {
     border: 0;
-    border-radius: 8px;
+    border-radius: 4px;
     padding: 6px 10px;
     cursor: pointer;
     background: #111;
     color: #fff;
+  }
+
+  /* Show selected color swatch */
+  .hl-swatch.active {
+    outline: 2px solid #000;
+  }
+
+  /* Space below color swatches */
+  .hl-colors {
+    padding-bottom: 5px;
   }
   

--- a/assets/js/highlighter.js
+++ b/assets/js/highlighter.js
@@ -27,16 +27,16 @@
     p = document.createElement('div');
     p.id = 'politeia-hl-note-popover';
     Object.assign(p.style, {
-      position: 'fixed', zIndex: '2147483647', background: '#fff', border: '1px solid #ddd',
-      borderRadius: '8px', boxShadow: '0 8px 24px rgba(0,0,0,.12)', padding: '10px',
+      position: 'fixed', zIndex: '2147483647', padding: '10px',
       maxWidth: '360px', display: 'none'
     });
+    // Basic popover structure for viewing notes
     p.innerHTML = `
-      <div class="note-content" role="dialog" aria-modal="true" aria-label="Nota del highlight">
+      <div class="note-content" role="dialog" aria-modal="true" aria-label="${politeiaHL.strings.viewNote}">
         <div class="note-text" id="hl-note-text" style="margin-bottom:8px; white-space:pre-wrap;"></div>
         <div class="actions" style="display:flex; gap:8px; justify-content:flex-end;">
-          <button id="hl-popover-delete">Eliminar</button>
-          <button id="hl-popover-close">Cerrar</button>
+          <button id="hl-popover-delete">${politeiaHL.strings.delete}</button>
+          <button id="hl-popover-close">${politeiaHL.strings.close}</button>
         </div>
       </div>
     `;
@@ -66,7 +66,7 @@
           hideNotePopover();
         } catch (err) {
           console.error(err);
-          alert('No se pudo eliminar el highlight.');
+          alert(politeiaHL.strings.errDelete);
         }
       }
     });
@@ -93,7 +93,7 @@
     pop.style.left = x + 'px';
     pop.style.top = y + 'px';
 
-    byId('hl-note-text').innerText = (text && String(text).trim()) || '(Sin nota)';
+    byId('hl-note-text').innerText = (text && String(text).trim()) || politeiaHL.strings.noNote;
     pop.dataset.hlId = id ? String(id) : '';
 
     pop.style.visibility = 'visible';
@@ -117,12 +117,13 @@
       borderRadius: '10px', boxShadow: '0 8px 24px rgba(0,0,0,.12)', padding: '10px',
       gap: '10px', maxWidth: '420px', width: 'max-content'
     });
+    // Toolbar contains color swatches, note textarea and action buttons
     bar.innerHTML = `
       <div class="hl-colors" style="display:flex; gap:6px; flex-wrap:wrap;"></div>
-      <textarea id="politeia-hl-note" placeholder="Nota opcional..." style="min-width:260px; min-height:60px;"></textarea>
+      <textarea id="politeia-hl-note" placeholder="${politeiaHL.strings.notePlaceholder}" style="min-width:260px; min-height:60px;"></textarea>
       <div style="display:flex; gap:8px; align-items:center;">
-        <button id="politeia-hl-save">Guardar</button>
-        <button id="politeia-hl-cancel" class="muted">Cancelar</button>
+        <button id="politeia-hl-save">${politeiaHL.strings.save}</button>
+        <button id="politeia-hl-cancel" class="muted">${politeiaHL.strings.cancel}</button>
       </div>
     `;
     document.body.appendChild(bar);
@@ -139,6 +140,8 @@
       });
       colorsWrap.appendChild(sw);
     });
+    // Select first color by default so user sees an active swatch
+    if (colorsWrap.firstElementChild) colorsWrap.firstElementChild.classList.add('active');
     return bar;
   }
 
@@ -218,20 +221,20 @@
       headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': API.nonce },
       body: JSON.stringify(payload)
     });
-    if (!res.ok) throw new Error('No se pudo crear el highlight');
+    if (!res.ok) throw new Error(politeiaHL.strings.errCreate);
     return res.json();
   }
   async function apiListHighlights(post_id) {
     const url = new URL(API.base, window.location.origin);
     url.searchParams.set('post_id', post_id);
     const res = await fetch(url.toString(), { credentials: 'same-origin', headers: { 'X-WP-Nonce': API.nonce } });
-    if (!res.ok) throw new Error('No se pudo obtener la lista');
+    if (!res.ok) throw new Error(politeiaHL.strings.errList);
     return res.json();
   }
   async function apiDeleteHighlight(id) {
     const url = new URL(API.base + '/' + id, window.location.origin);
     const res = await fetch(url.toString(), { method: 'DELETE', credentials: 'same-origin', headers: { 'X-WP-Nonce': API.nonce } });
-    if (!res.ok && res.status !== 204) throw new Error('No se pudo borrar');
+    if (!res.ok && res.status !== 204) throw new Error(politeiaHL.strings.errDeleteGeneric);
     return true;
   }
 
@@ -343,15 +346,17 @@
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'hl-note-dot';
+    // Small square badge next to highlighted text showing there is a note
+    const color = markEl.style.background;
     Object.assign(btn.style, {
       display: 'inline-block', width: '10px', height: '10px', marginLeft: '4px',
-      borderRadius: '50%', border: '0', background: '#7c3aed', cursor: 'pointer', verticalAlign: 'middle'
+      borderRadius: '2px', border: '0', background: color, cursor: 'pointer', verticalAlign: 'middle'
     });
-    btn.setAttribute('aria-label', 'Ver nota');
-    btn.title = 'Ver nota';
+    btn.setAttribute('aria-label', politeiaHL.strings.viewNote);
+    btn.title = politeiaHL.strings.viewNote;
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
-      const txt = notesById.get(Number(id)) || noteText || '(Sin nota)';
+      const txt = notesById.get(Number(id)) || noteText || politeiaHL.strings.noNote;
       showNotePopover(btn, txt, id);
     });
     markEl.parentNode.insertBefore(btn, markEl.nextSibling);
@@ -436,7 +441,7 @@
           }
         } catch (err) {
           console.error(err);
-          alert('No se pudo guardar el highlight.');
+          alert(politeiaHL.strings.errSave);
         } finally {
           hideToolbar();
           window.getSelection()?.removeAllRanges();

--- a/includes/class-politeia-hl-render.php
+++ b/includes/class-politeia-hl-render.php
@@ -9,7 +9,7 @@ class Politeia_HL_Render {
     }
 
     public function enqueue_assets() {
-        // Carga solo en posts singulares y con usuario logueado
+        // Load only on single posts for logged-in users
         if ( ! is_singular('post') || ! is_user_logged_in() ) return;
 
         // CSS
@@ -29,32 +29,36 @@ class Politeia_HL_Render {
             true
         );
 
-        // Variables para el frontend
+        // Data passed to the frontend
         wp_localize_script(
             'politeia-hl-js',
             'politeiaHL',
             [
-                // 👇 RELATIVA: evita mixed content y asegura envío de cookies same-origin
+                // Relative URL avoids mixed content and ensures same-origin cookies
                 'rest_url'    => esc_url_raw( wp_make_link_relative( rest_url( 'politeia/v1/highlights' ) ) ),
                 'nonce'       => wp_create_nonce('wp_rest'),
                 'currentUser' => get_current_user_id(),
                 'colors'      => [ '#ffe066','#ffda79','#c4f1be','#a0e7e5','#b4b4ff','#ffd6e0' ],
+                'strings'     => [
+                    'notePlaceholder'  => __( 'Optional note...', 'politeia-highlights' ),
+                    'save'             => __( 'Save', 'politeia-highlights' ),
+                    'cancel'           => __( 'Cancel', 'politeia-highlights' ),
+                    'viewNote'         => __( 'View note', 'politeia-highlights' ),
+                    'delete'           => __( 'Delete', 'politeia-highlights' ),
+                    'close'            => __( 'Close', 'politeia-highlights' ),
+                    'noNote'           => __( '(No note)', 'politeia-highlights' ),
+                    'errDelete'        => __( 'Could not delete highlight.', 'politeia-highlights' ),
+                    'errSave'          => __( 'Could not save highlight.', 'politeia-highlights' ),
+                    'errCreate'        => __( 'Could not create highlight.', 'politeia-highlights' ),
+                    'errList'          => __( 'Could not fetch list.', 'politeia-highlights' ),
+                    'errDeleteGeneric' => __( 'Could not delete.', 'politeia-highlights' ),
+                ],
             ]
         );
-        wp_localize_script(
-            'politeia-hl-js',
-            'politeiaHL',
-            [
-              'rest_url'    => esc_url_raw( wp_make_link_relative( rest_url( 'politeia/v1/highlights' ) ) ),
-              'nonce'       => wp_create_nonce('wp_rest'),
-              'currentUser' => get_current_user_id(),
-              'colors'      => [ '#ffe066','#ffda79','#c4f1be','#a0e7e5','#b4b4ff','#ffd6e0' ],
-            ]
-        );          
     }
 
     public function append_container( $content ) {
-        // Solo agregar contenedor en posts singulares y con usuario logueado
+        // Only add container on single posts and for logged-in users
         if ( is_singular('post') && is_user_logged_in() ) {
             $content .= '<div id="politeia-highlighter-root" data-post-id="' . esc_attr( get_the_ID() ) . '"></div>';
         }

--- a/includes/class-politeia-hl-schema.php
+++ b/includes/class-politeia-hl-schema.php
@@ -3,13 +3,20 @@ if ( ! defined('ABSPATH') ) exit;
 
 class Politeia_HL_Schema {
 
-    const TABLE = 'wp_user_highlights'; // usa $wpdb->prefix en runtime
+    // Base table name; $wpdb->prefix is added at runtime
+    const TABLE = 'wp_user_highlights';
 
+    /**
+     * Return full table name with WordPress prefix.
+     */
     public static function table_name() {
         global $wpdb;
         return $wpdb->prefix . 'user_highlights';
     }
 
+    /**
+     * Create database table to store highlights.
+     */
     public static function create_table() {
         global $wpdb;
 
@@ -36,7 +43,7 @@ class Politeia_HL_Schema {
 
         dbDelta( $sql );
 
-        // Guarda versión para futuras migraciones
+        // Store version for future migrations
         add_option('politeia_hl_db_version', POLITEIA_HL_VERSION);
     }
 }

--- a/politeia-highlights.php
+++ b/politeia-highlights.php
@@ -1,15 +1,15 @@
 <?php
 /**
  * Plugin Name: Politeia Highlights
- * Description: Permite a los usuarios resaltar texto en los posts y guardar sus highlights.
+ * Description: Allows users to highlight text in posts and save their notes.
  * Version: 0.1.0
  * Author: Politeia
  * Text Domain: politeia-highlights
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit; // Evita acceso directo
+if ( ! defined( 'ABSPATH' ) ) exit; // Prevent direct access
 
-// ===== Constantes =====
+// ===== Constants =====
 define( 'POLITEIA_HL_VERSION', '0.1.0' );
 define( 'POLITEIA_HL_PATH', plugin_dir_path( __FILE__ ) );
 define( 'POLITEIA_HL_URL', plugin_dir_url( __FILE__ ) );
@@ -19,8 +19,9 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-politeia-hl-schema.ph
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-politeia-hl-rest.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-politeia-hl-render.php';
 
-// ===== Activación =====
+// ===== Activation =====
 function politeia_hl_activate() {
+    // Create database table on plugin activation
     require_once POLITEIA_HL_PATH . 'includes/class-politeia-hl-schema.php';
     Politeia_HL_Schema::create_table();
 }
@@ -28,6 +29,7 @@ register_activation_hook( __FILE__, 'politeia_hl_activate' );
 
 // ===== Init =====
 function politeia_hl_init() {
+    // Register REST routes and front-end renderer
     new Politeia_HL_REST();
     new Politeia_HL_Render();
 }


### PR DESCRIPTION
## Summary
- translate plugin strings and expose them to JS for localization
- style note badge and popover to match chosen highlight color and minimal design
- highlight selected color swatch and add spacing in toolbar

## Testing
- `composer lint-phpcs`


------
https://chatgpt.com/codex/tasks/task_e_68b980bb65948332832097d5f6a390ed