### PR TITLE
Match toolbar buttons to note popover style

### DIFF
--- a/assets/css/highlighter.css
+++ b/assets/css/highlighter.css
@@ -36,7 +36,8 @@
     justify-content: flex-end;
     gap: 8px;
   }
-  #politeia-hl-note-popover .actions button {
+  #politeia-hl-note-popover .actions button,
+  #politeia-hl-toolbar button:not(.hl-swatch) {
     border: 0;
     border-radius: 4px;
     padding: 6px 10px;

--- a/assets/js/highlighter.js
+++ b/assets/js/highlighter.js
@@ -123,7 +123,7 @@
       <textarea id="politeia-hl-note" placeholder="${politeiaHL.strings.notePlaceholder}" style="min-width:260px; min-height:60px;"></textarea>
       <div style="display:flex; gap:8px; align-items:center;">
         <button id="politeia-hl-save">${politeiaHL.strings.save}</button>
-        <button id="politeia-hl-cancel" class="muted">${politeiaHL.strings.cancel}</button>
+        <button id="politeia-hl-cancel">${politeiaHL.strings.cancel}</button>
       </div>
     `;
     document.body.appendChild(bar);


### PR DESCRIPTION
## Summary
- Apply shared button styles so toolbar actions use the same dark theme as note popover buttons
- Remove unused `muted` class from the toolbar cancel button

## Testing
- `composer lint-phpcs`

------
https://chatgpt.com/codex/tasks/task_e_68b9be76ab548332b2adbf513c46e7a1