### PR TITLE
Fix highlight offsets with exact text search

### DIFF
--- a/assets/js/highlighter.js
+++ b/assets/js/highlighter.js
@@ -371,7 +371,6 @@
   const normalizeSpaces = (s) => (s || '').replace(/\s+/g, ' ').trim();
 
     function findBestMatch(exact, prefix, suffix, scopeEl) {
-      exact = normalizeSpaces(exact);
       const pfx = normalizeSpaces(prefix);
       const sfx = normalizeSpaces(suffix);
       if (!exact) return null;
@@ -404,7 +403,7 @@
       if (best) return best;
 
       // Fallback: allow matches spanning multiple text nodes.
-      const joined = normalizeSpaces(scope.innerText || scope.textContent || '');
+      const joined = scope.textContent || '';
       const idx = joined.indexOf(exact);
       if (idx === -1) return null;
 


### PR DESCRIPTION
## Summary
- prevent reflowed highlights by searching for exact text without whitespace normalization
- compute multi-node matches from raw `textContent`

## Testing
- `composer run lint-phpcs`

------
https://chatgpt.com/codex/tasks/task_e_68bb412e358c8332aa3186430af16f4c