### PR TITLE
Add shortcode for sortable highlights table

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -1,0 +1,16 @@
+.politeia-hl-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.politeia-hl-table th,
+.politeia-hl-table td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+.politeia-hl-table th {
+    cursor: pointer;
+    background: #f5f5f5;
+}

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const table = document.querySelector('.politeia-hl-table');
+  if (!table) return;
+
+  const tbody = table.querySelector('tbody');
+  table.querySelectorAll('th[data-sort]').forEach(function(th) {
+    th.addEventListener('click', function() {
+      const key = th.dataset.sort;
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      const direction = th.classList.contains('asc') ? -1 : 1;
+
+      rows.sort(function(a, b) {
+        const aVal = getVal(a, key);
+        const bVal = getVal(b, key);
+        if (key === 'index' || key === 'date') {
+          return (aVal - bVal) * direction;
+        }
+        if (key === 'color') {
+          return aVal.localeCompare(bVal) * direction;
+        }
+        return 0;
+      });
+
+      tbody.innerHTML = '';
+      rows.forEach(function(row) { tbody.appendChild(row); });
+
+      table.querySelectorAll('th[data-sort]').forEach(function(h) {
+        h.classList.remove('asc', 'desc');
+      });
+      th.classList.add(direction === 1 ? 'asc' : 'desc');
+    });
+  });
+
+  function getVal(row, key) {
+    const cell = row.querySelector('.hl-' + key);
+    if (key === 'index') {
+      return parseInt(cell.textContent, 10);
+    }
+    if (key === 'date') {
+      return parseInt(cell.dataset.timestamp, 10);
+    }
+    if (key === 'color') {
+      return cell.dataset.color;
+    }
+    return cell.textContent;
+  }
+});

--- a/modules/highlight-table/class-politeia-hl-highlights-table.php
+++ b/modules/highlight-table/class-politeia-hl-highlights-table.php
@@ -1,0 +1,79 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class Politeia_HL_Highlights_Table {
+
+    public function __construct() {
+        add_shortcode( 'politeia_highlights_table', [ $this, 'render_shortcode' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+    }
+
+    public function enqueue_assets() {
+        if ( ! is_user_logged_in() ) return;
+        if ( ! is_singular() || ! has_shortcode( get_post()->post_content ?? '', 'politeia_highlights_table' ) ) return;
+
+        wp_enqueue_style(
+            'politeia-hl-table-css',
+            POLITEIA_HL_URL . 'modules/highlight-table/assets/css/highlight-table.css',
+            [],
+            POLITEIA_HL_VERSION
+        );
+
+        wp_enqueue_script(
+            'politeia-hl-table-js',
+            POLITEIA_HL_URL . 'modules/highlight-table/assets/js/highlight-table.js',
+            [],
+            POLITEIA_HL_VERSION,
+            true
+        );
+    }
+
+    public function render_shortcode() {
+        if ( ! is_user_logged_in() ) return '';
+
+        global $wpdb;
+        $table   = Politeia_HL_Schema::table_name();
+        $user_id = get_current_user_id();
+
+        $query   = $wpdb->prepare( "SELECT * FROM {$table} WHERE user_id = %d ORDER BY created_at DESC", $user_id ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $results = $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+        if ( empty( $results ) ) {
+            return '<p>' . esc_html__( 'No highlights found.', 'politeia-highlights' ) . '</p>';
+        }
+
+        $rows  = '';
+        $index = 1;
+        foreach ( $results as $row ) {
+            $date       = mysql2date( get_option( 'date_format' ), $row->created_at );
+            $timestamp  = strtotime( $row->created_at );
+            $note       = $row->note ? esc_html( $row->note ) : '';
+            $color      = esc_attr( $row->color );
+            $post_title = esc_html( get_the_title( $row->post_id ) );
+
+            $rows .= '<tr>';
+            $rows .= '<td class="hl-index">' . intval( $index ) . '</td>';
+            $rows .= '<td class="hl-text">' . esc_html( $row->anchor_exact ) . '</td>';
+            $rows .= '<td class="hl-date" data-timestamp="' . intval( $timestamp ) . '">' . esc_html( $date ) . '</td>';
+            $rows .= '<td class="hl-note">' . $note . '</td>';
+            $rows .= '<td class="hl-color" data-color="' . $color . '" style="background-color:' . $color . ';"></td>';
+            $rows .= '<td class="hl-post">' . $post_title . '</td>';
+            $rows .= '</tr>';
+            ++$index;
+        }
+
+        $html  = '<table class="politeia-hl-table">';
+        $html .= '<thead><tr>';
+        $html .= '<th data-sort="index">' . esc_html__( 'Index', 'politeia-highlights' ) . '</th>';
+        $html .= '<th>' . esc_html__( 'Text', 'politeia-highlights' ) . '</th>';
+        $html .= '<th data-sort="date">' . esc_html__( 'Date', 'politeia-highlights' ) . '</th>';
+        $html .= '<th>' . esc_html__( 'Note', 'politeia-highlights' ) . '</th>';
+        $html .= '<th data-sort="color">' . esc_html__( 'Color', 'politeia-highlights' ) . '</th>';
+        $html .= '<th>' . esc_html__( 'Post', 'politeia-highlights' ) . '</th>';
+        $html .= '</tr></thead>';
+        $html .= '<tbody>' . $rows . '</tbody>';
+        $html .= '</table>';
+
+        return $html;
+    }
+}

--- a/politeia-highlights.php
+++ b/politeia-highlights.php
@@ -18,6 +18,7 @@ define( 'POLITEIA_HL_URL', plugin_dir_url( __FILE__ ) );
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-politeia-hl-schema.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-politeia-hl-rest.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-politeia-hl-render.php';
+require_once plugin_dir_path( __FILE__ ) . 'modules/highlight-table/class-politeia-hl-highlights-table.php';
 
 // ===== Activation =====
 function politeia_hl_activate() {
@@ -32,5 +33,6 @@ function politeia_hl_init() {
     // Register REST routes and front-end renderer
     new Politeia_HL_REST();
     new Politeia_HL_Render();
+    new Politeia_HL_Highlights_Table();
 }
 add_action( 'plugins_loaded', 'politeia_hl_init' );


### PR DESCRIPTION
## Summary
- add highlight-table module with shortcode that renders a sortable table of user highlights
- wire up module in main plugin file and enqueue dedicated CSS/JS assets

## Testing
- `composer install`
- `composer lint-phpcs`


------
https://chatgpt.com/codex/tasks/task_e_68bb499cfcb08332a64e8be0ee0acccf