### PR TITLE
Replace color dropdown with swatch toolbar

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -19,3 +19,11 @@
     display: block;
     font-size: 0.9em;
 }
+
+.hl-swatch.active {
+    outline: 2px solid #000;
+}
+
+.hl-colors {
+    padding-bottom: 10px;
+}

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -3,15 +3,31 @@ document.addEventListener('DOMContentLoaded', function() {
   if (!table || !window.politeiaHLTable) return;
 
   const tbody = table.querySelector('tbody');
-  const select = document.querySelector('#politeia-hl-color');
+  const colorsWrap = document.querySelector('#politeia-hl-color');
 
-  if (select && Array.isArray(politeiaHLTable.colors)) {
-    politeiaHLTable.colors.forEach(function(c) {
-      const opt = document.createElement('option');
-      opt.value = c;
-      opt.textContent = c;
-      select.appendChild(opt);
+  if (colorsWrap && Array.isArray(politeiaHLTable.colors)) {
+    const allBtn = document.createElement('button');
+    allBtn.type = 'button';
+    allBtn.textContent = 'All';
+    allBtn.className = 'hl-swatch';
+    Object.assign(allBtn.style, {
+      height: '22px', borderRadius: '4px',
+      border: '1px solid rgba(0,0,0,.15)', background: '#fff',
+      cursor: 'pointer', padding: '0 8px'
     });
+    colorsWrap.appendChild(allBtn);
+    politeiaHLTable.colors.forEach(function(c) {
+      const sw = document.createElement('button');
+      sw.type = 'button';
+      sw.className = 'hl-swatch';
+      sw.setAttribute('data-color', c);
+      Object.assign(sw.style, {
+        width: '22px', height: '22px', borderRadius: '50%',
+        border: '1px solid rgba(0,0,0,.15)', background: c, cursor: 'pointer'
+      });
+      colorsWrap.appendChild(sw);
+    });
+    if (colorsWrap.firstElementChild) colorsWrap.firstElementChild.classList.add('active');
   }
 
   function escapeHtml(str) {
@@ -50,9 +66,13 @@ document.addEventListener('DOMContentLoaded', function() {
       });
   }
 
-  if (select) {
-    select.addEventListener('change', function() {
-      fetchHighlights(this.value);
+  if (colorsWrap) {
+    colorsWrap.addEventListener('click', function(e) {
+      const btn = e.target.closest('.hl-swatch');
+      if (!btn) return;
+      colorsWrap.querySelectorAll('.hl-swatch').forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      fetchHighlights(btn.dataset.color || '');
     });
   }
 

--- a/modules/highlight-table/class-politeia-hl-highlights-table.php
+++ b/modules/highlight-table/class-politeia-hl-highlights-table.php
@@ -43,9 +43,7 @@ class Politeia_HL_Highlights_Table {
 
         $html  = '<div class="politeia-hl-filter">';
         $html .= '<label for="politeia-hl-color">' . esc_html__( 'Color', 'politeia-highlights' ) . '</label>';
-        $html .= '<select id="politeia-hl-color">';
-        $html .= '<option value="">' . esc_html__( 'All', 'politeia-highlights' ) . '</option>';
-        $html .= '</select>';
+        $html .= '<div id="politeia-hl-color" class="hl-colors" style="display:flex; gap:6px; flex-wrap:wrap;"></div>';
         $html .= '</div>';
 
         $html .= '<table class="politeia-hl-table">';


### PR DESCRIPTION
## Summary
- Replace highlight table color filter dropdown with color swatch toolbar
- Add JS to build swatches, handle selection, and fetch filtered highlights
- Add CSS for active swatch styling

## Testing
- `php -l modules/highlight-table/class-politeia-hl-highlights-table.php`
- `node --check modules/highlight-table/assets/js/highlight-table.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb5631fd908332bf561d23159db1b2