### PR TITLE
Display post metadata in highlight table

### DIFF
--- a/includes/class-politeia-hl-rest.php
+++ b/includes/class-politeia-hl-rest.php
@@ -239,7 +239,8 @@ class Politeia_HL_REST {
 		}
 
 		foreach ( $rows as &$row ) {
-				$row['post_title'] = get_the_title( $row['post_id'] );
+			$row['post_title'] = get_the_title( $row['post_id'] );
+			$row['post_url']   = get_permalink( $row['post_id'] );
 		}
 
 			return rest_ensure_response( $rows );

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -15,9 +15,17 @@
     background: #f5f5f5;
 }
 
-.politeia-hl-table .hl-date-time {
+
+.politeia-hl-table .hl-text .hl-post-title,
+.politeia-hl-table .hl-text .hl-date {
     display: block;
-    font-size: 0.9em;
+    font-size: 13px;
+}
+
+.politeia-hl-table .hl-text .hl-highlight {
+    display: block;
+    font-size: 18px;
+    margin: 4px 0;
 }
 
 .hl-swatch.active {

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -55,12 +55,12 @@ document.addEventListener('DOMContentLoaded', function() {
           const timeStr = created.toLocaleTimeString();
           tr.innerHTML =
             '<td class="hl-index">' + (idx + 1) + '</td>' +
-            '<td class="hl-text">' + escapeHtml(row.anchor_exact) + '</td>' +
-            '<td class="hl-date" data-timestamp="' + Math.floor(created.getTime() / 1000) + '">' +
-              '<span class="hl-date-day">' + dateStr + '</span><br><small class="hl-date-time">' + timeStr + '</small>' +
+            '<td class="hl-text">' +
+              '<a class="hl-post-title" href="' + escapeHtml(row.post_url) + '">' + escapeHtml(row.post_title) + '</a>' +
+              '<div class="hl-highlight">' + escapeHtml(row.anchor_exact) + '</div>' +
+              '<div class="hl-date" data-timestamp="' + Math.floor(created.getTime() / 1000) + '">' + dateStr + ' ' + timeStr + '</div>' +
             '</td>' +
-            '<td class="hl-note">' + escapeHtml(row.note) + '</td>' +
-            '<td class="hl-post">' + escapeHtml(row.post_title) + '</td>';
+            '<td class="hl-note">' + escapeHtml(row.note) + '</td>';
           tbody.appendChild(tr);
         });
       });

--- a/modules/highlight-table/class-politeia-hl-highlights-table.php
+++ b/modules/highlight-table/class-politeia-hl-highlights-table.php
@@ -49,10 +49,8 @@ class Politeia_HL_Highlights_Table {
         $html .= '<table class="politeia-hl-table">';
         $html .= '<thead><tr>';
         $html .= '<th data-sort="index">' . esc_html__( 'Index', 'politeia-highlights' ) . '</th>';
-        $html .= '<th>' . esc_html__( 'Text', 'politeia-highlights' ) . '</th>';
-        $html .= '<th data-sort="date">' . esc_html__( 'Date', 'politeia-highlights' ) . '</th>';
+        $html .= '<th>' . esc_html__( 'Highlighted Text', 'politeia-highlights' ) . '</th>';
         $html .= '<th>' . esc_html__( 'Note', 'politeia-highlights' ) . '</th>';
-        $html .= '<th>' . esc_html__( 'Post', 'politeia-highlights' ) . '</th>';
         $html .= '</tr></thead>';
         $html .= '<tbody></tbody>';
         $html .= '</table>';


### PR DESCRIPTION
## Summary
- embed post title and timestamp in highlight rows
- reduce table to index, highlighted text and note columns
- style highlight cell for title, highlight and timestamp

## Testing
- `composer run lint-phpcs`


------
https://chatgpt.com/codex/tasks/task_e_68bb6c7b4c2c8332a23dec97af85f6ab