### PR TITLE
style: adjust notes font size and add divider

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -28,6 +28,18 @@
     margin: 4px 0;
 }
 
+/* Style for note column */
+.politeia-hl-table .hl-note {
+    font-size: 18px;
+}
+
+/* Thin separator above date/time */
+.politeia-hl-table .hl-date-separator {
+    border: none;
+    border-top: 1px solid #ccc;
+    margin: 4px 0;
+}
+
 .hl-swatch.active {
     outline: 2px solid #000;
 }

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -58,6 +58,7 @@ document.addEventListener('DOMContentLoaded', function() {
             '<td class="hl-text">' +
               '<a class="hl-post-title" href="' + escapeHtml(row.post_url) + '">' + escapeHtml(row.post_title) + '</a>' +
               '<div class="hl-highlight">' + escapeHtml(row.anchor_exact) + '</div>' +
+              '<hr class="hl-date-separator" />' +
               '<div class="hl-date" data-timestamp="' + Math.floor(created.getTime() / 1000) + '">' + dateStr + ' ' + timeStr + '</div>' +
             '</td>' +
             '<td class="hl-note">' + escapeHtml(row.note) + '</td>';


### PR DESCRIPTION
## Summary
- enlarge note text in highlights table
- add horizontal divider before timestamp

## Testing
- `composer lint-phpcs`

------
https://chatgpt.com/codex/tasks/task_e_68bb8608b58883329d38f56642819b01