### PR TITLE
Improve highlights table layout and translations

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -3,6 +3,12 @@
     border-collapse: collapse;
 }
 
+.politeia-hl-filter {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
 .politeia-hl-table th,
 .politeia-hl-table td {
     border: 1px solid #ccc;
@@ -20,12 +26,15 @@
 .politeia-hl-table .hl-text .hl-date {
     display: block;
     font-size: 13px;
+    opacity: 0.3;
+    font-weight: 500;
 }
 
 .politeia-hl-table .hl-text .hl-highlight {
     display: block;
     font-size: 18px;
     margin: 4px 0;
+    padding: 12px;
 }
 
 /* Style for note column */
@@ -46,4 +55,8 @@
 
 .hl-colors {
     padding-bottom: 10px;
+}
+
+.politeia-hl-filter .hl-colors {
+    margin-left: auto;
 }

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
   if (colorsWrap && Array.isArray(politeiaHLTable.colors)) {
     const allBtn = document.createElement('button');
     allBtn.type = 'button';
-    allBtn.textContent = 'All';
+    allBtn.textContent = politeiaHLTable.allLabel;
     allBtn.className = 'hl-swatch';
     Object.assign(allBtn.style, {
       height: '22px', borderRadius: '4px',
@@ -48,13 +48,12 @@ document.addEventListener('DOMContentLoaded', function() {
       .then(res => res.json())
       .then(data => {
         tbody.innerHTML = '';
-        data.forEach(function(row, idx) {
+        data.forEach(function(row) {
           const tr = document.createElement('tr');
           const created = new Date(row.created_at.replace(' ', 'T'));
           const dateStr = created.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
           const timeStr = created.toLocaleTimeString();
           tr.innerHTML =
-            '<td class="hl-index">' + (idx + 1) + '</td>' +
             '<td class="hl-text">' +
               '<a class="hl-post-title" href="' + escapeHtml(row.post_url) + '">' + escapeHtml(row.post_title) + '</a>' +
               '<div class="hl-highlight">' + escapeHtml(row.anchor_exact) + '</div>' +
@@ -101,9 +100,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
   function getVal(row, key) {
     const cell = row.querySelector('.hl-' + key);
-    if (key === 'index') {
-      return parseInt(cell.textContent, 10);
-    }
     if (key === 'date') {
       return parseInt(cell.dataset.timestamp, 10);
     }

--- a/modules/highlight-table/class-politeia-hl-highlights-table.php
+++ b/modules/highlight-table/class-politeia-hl-highlights-table.php
@@ -31,9 +31,10 @@ class Politeia_HL_Highlights_Table {
             'politeia-hl-table-js',
             'politeiaHLTable',
             [
-                'restUrl' => esc_url_raw( wp_make_link_relative( rest_url( 'politeia/v1/user-highlights' ) ) ),
-                'nonce'   => wp_create_nonce( 'wp_rest' ),
-                'colors'  => [ '#ffe066','#ffda79','#c4f1be','#a0e7e5','#b4b4ff','#ffd6e0' ],
+                'restUrl'  => esc_url_raw( wp_make_link_relative( rest_url( 'politeia/v1/user-highlights' ) ) ),
+                'nonce'    => wp_create_nonce( 'wp_rest' ),
+                'colors'   => [ '#ffe066','#ffda79','#c4f1be','#a0e7e5','#b4b4ff','#ffd6e0' ],
+                'allLabel' => esc_html__( 'All', 'politeia-highlights' ),
             ]
         );
     }
@@ -42,13 +43,12 @@ class Politeia_HL_Highlights_Table {
         if ( ! is_user_logged_in() ) return '';
 
         $html  = '<div class="politeia-hl-filter">';
-        $html .= '<label for="politeia-hl-color">' . esc_html__( 'Color', 'politeia-highlights' ) . '</label>';
+        $html .= '<div class="politeia-hl-title">' . esc_html__( 'My highlights', 'politeia-highlights' ) . '</div>';
         $html .= '<div id="politeia-hl-color" class="hl-colors" style="display:flex; gap:6px; flex-wrap:wrap;"></div>';
         $html .= '</div>';
 
         $html .= '<table class="politeia-hl-table">';
         $html .= '<thead><tr>';
-        $html .= '<th data-sort="index">' . esc_html__( 'Index', 'politeia-highlights' ) . '</th>';
         $html .= '<th>' . esc_html__( 'Highlighted Text', 'politeia-highlights' ) . '</th>';
         $html .= '<th>' . esc_html__( 'Note', 'politeia-highlights' ) . '</th>';
         $html .= '</tr></thead>';


### PR DESCRIPTION
## Summary
- Align the color filter to the right and show a translatable "My highlights" title on the left
- Drop the index column and word label, adding proper translation support for all UI strings
- Refine styling for highlight entries, including padding and dimmed metadata

## Testing
- `composer lint-phpcs`

------
https://chatgpt.com/codex/tasks/task_e_68bc1764e86c8332a80cd515ec8a412d