### PR TITLE
Adjust mobile table cell layout

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -82,7 +82,8 @@
 
     .politeia-hl-table tbody td {
         display: block;
-        width: 100%;
+        width: 80%;
+        margin: auto;
         text-align: center;
     }
 


### PR DESCRIPTION
## Summary
- Improve mobile table formatting by narrowing cells to 80% width and centering them

## Testing
- `composer lint-phpcs`


------
https://chatgpt.com/codex/tasks/task_e_68bc246e47ec83329ccc685567e3bab2