### PR TITLE
Enable inline note editing in highlight table

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -51,6 +51,20 @@
     font-size: 18px;
 }
 
+.politeia-hl-table .hl-note .hl-note-edit {
+    margin-left: 8px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.politeia-hl-table .hl-note textarea {
+    width: 100%;
+    box-sizing: border-box;
+    min-height: 60px;
+    font-size: 16px;
+    margin-bottom: 4px;
+}
+
 /* Thin separator above date/time */
 .politeia-hl-table .hl-date-separator {
     border: none;

--- a/modules/highlight-table/class-politeia-hl-highlights-table.php
+++ b/modules/highlight-table/class-politeia-hl-highlights-table.php
@@ -31,10 +31,14 @@ class Politeia_HL_Highlights_Table {
             'politeia-hl-table-js',
             'politeiaHLTable',
             [
-                'restUrl'  => esc_url_raw( wp_make_link_relative( rest_url( 'politeia/v1/user-highlights' ) ) ),
-                'nonce'    => wp_create_nonce( 'wp_rest' ),
-                'colors'   => [ '#ffe066','#ffda79','#c4f1be','#a0e7e5','#b4b4ff','#ffd6e0' ],
-                'allLabel' => esc_html__( 'All', 'politeia-highlights' ),
+                'restUrl'   => esc_url_raw( wp_make_link_relative( rest_url( 'politeia/v1/user-highlights' ) ) ),
+                'apiBase'   => esc_url_raw( wp_make_link_relative( rest_url( 'politeia/v1/highlights' ) ) ),
+                'nonce'     => wp_create_nonce( 'wp_rest' ),
+                'colors'    => [ '#ffe066','#ffda79','#c4f1be','#a0e7e5','#b4b4ff','#ffd6e0' ],
+                'allLabel'  => esc_html__( 'All', 'politeia-highlights' ),
+                'editLabel' => esc_html__( 'Edit', 'politeia-highlights' ),
+                'saveLabel' => esc_html__( 'Save', 'politeia-highlights' ),
+                'errSave'   => esc_html__( 'Could not save note.', 'politeia-highlights' ),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- allow editing highlight notes directly in table rows
- add styles for edit link and textarea
- expose highlight API details to frontend script

## Testing
- `composer lint-phpcs`

------
https://chatgpt.com/codex/tasks/task_e_68bc296e9e24833285f12e7d2668bd58