### PR TITLE
Fix note column width and font when editing

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -61,7 +61,7 @@
     width: 100%;
     box-sizing: border-box;
     min-height: 60px;
-    font-size: 16px;
+    font: inherit;
     margin-bottom: 4px;
 }
 

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -95,6 +95,8 @@ document.addEventListener('DOMContentLoaded', function() {
       const textarea = document.createElement('textarea');
       textarea.className = 'hl-note-input';
       textarea.value = text;
+      const width = cell.getBoundingClientRect().width;
+      cell.style.width = width + 'px';
       textarea.style.width = '100%';
       cell.querySelector('.note-display').replaceWith(textarea);
       link.textContent = saveLabel;
@@ -117,6 +119,7 @@ document.addEventListener('DOMContentLoaded', function() {
         textarea.replaceWith(div);
         link.textContent = editLabel;
         delete cell.dataset.editing;
+        cell.style.width = '';
       } catch (err) {
         alert(errSave);
       }


### PR DESCRIPTION
## Summary
- keep note cell width when entering edit mode
- inherit note font in textarea so edit view matches display

## Testing
- `composer run lint-phpcs`


------
https://chatgpt.com/codex/tasks/task_e_68bc2c0099448332b4cc5326a20834b6