### PR TITLE
Improve note editing UX in highlight table

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -63,6 +63,15 @@
     min-height: 60px;
     font: inherit;
     margin-bottom: 4px;
+    border: 1px solid #000;
+    outline: none;
+    box-shadow: none;
+}
+
+.politeia-hl-table .hl-note textarea:focus {
+    border: 1px solid #000;
+    outline: none;
+    box-shadow: none;
 }
 
 /* Thin separator above date/time */

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -99,6 +99,12 @@ document.addEventListener('DOMContentLoaded', function() {
       cell.style.width = width + 'px';
       textarea.style.width = '100%';
       cell.querySelector('.note-display').replaceWith(textarea);
+      const resize = () => {
+        textarea.style.height = 'auto';
+        textarea.style.height = textarea.scrollHeight + 'px';
+      };
+      resize();
+      textarea.addEventListener('input', resize);
       link.textContent = saveLabel;
       cell.dataset.editing = '1';
       textarea.focus();


### PR DESCRIPTION
## Summary
- auto-resize note textarea to fit its content while editing
- simplify textarea styling to a consistent 1px black border with no focus outline

## Testing
- `composer lint-phpcs`


------
https://chatgpt.com/codex/tasks/task_e_68bc2e93fbb0833291523de6445cc1f4