### PR TITLE
Right-align and recolor note edit link

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -49,12 +49,20 @@
 /* Style for note column */
 .politeia-hl-table .hl-note {
     font-size: 18px;
+    display: flex;
+    align-items: flex-start;
+}
+
+.politeia-hl-table .hl-note .note-display,
+.politeia-hl-table .hl-note textarea {
+    flex: 1;
 }
 
 .politeia-hl-table .hl-note .hl-note-edit {
-    margin-left: 8px;
+    margin-left: auto;
     font-size: 14px;
     cursor: pointer;
+    color: #2196F3;
 }
 
 .politeia-hl-table .hl-note textarea {

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const tbody = table.querySelector('tbody');
   const colorsWrap = document.querySelector('#politeia-hl-color');
   const editLabel = politeiaHLTable.editLabel || 'Edit';
+  const addLabel = politeiaHLTable.addLabel || 'Add Note';
   const saveLabel = politeiaHLTable.saveLabel || 'Save';
   const errSave = politeiaHLTable.errSave || 'Could not save note.';
 
@@ -65,7 +66,7 @@ document.addEventListener('DOMContentLoaded', function() {
               </td>
               <td class="hl-note" data-id="${row.id}">
                 <div class="note-display">${escapeHtml(row.note)}</div>
-                <a href="#" class="hl-note-edit">${editLabel}</a>
+                <a href="#" class="hl-note-edit">${(row.note && String(row.note).trim()) ? editLabel : addLabel}</a>
               </td>`;
           tbody.appendChild(tr);
         });


### PR DESCRIPTION
## Summary
- Right-align the note edit link and color it blue
- Show "Add Note" for highlights without notes

## Testing
- `composer lint-phpcs`

------
https://chatgpt.com/codex/tasks/task_e_68bc3172849c8332ad88cd2c54133680