### PR TITLE
Fix note cell height and position edit controls at bottom

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -49,17 +49,19 @@
 /* Style for note column */
 .politeia-hl-table .hl-note {
     font-size: 18px;
-    display: flex;
-    align-items: flex-start;
+    position: relative;
+    padding-bottom: 24px;
 }
 
 .politeia-hl-table .hl-note .note-display,
 .politeia-hl-table .hl-note textarea {
-    flex: 1;
+    display: block;
 }
 
 .politeia-hl-table .hl-note .hl-note-edit {
-    margin-left: auto;
+    position: absolute;
+    right: 4px;
+    bottom: 4px;
     font-size: 14px;
     cursor: pointer;
     color: #2196F3;


### PR DESCRIPTION
## Summary
- Ensure note cells have same height as highlight text
- Move note edit/add control to bottom of note cell

## Testing
- `composer run-script lint-phpcs`

------
https://chatgpt.com/codex/tasks/task_e_68bc34b7ef408332ac40527d984fb8cb