### PR TITLE
Fix note column width consistency across color filters

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -20,6 +20,12 @@
     text-align: left;
 }
 
+/* Keep the note column width consistent across filters */
+.politeia-hl-table th:nth-child(2),
+.politeia-hl-table td:nth-child(2) {
+    width: 30%;
+}
+
 .politeia-hl-table th + th,
 .politeia-hl-table td + td {
     border-left: 1px solid #ccc;


### PR DESCRIPTION
## Summary
- keep note column width at 30% so changing highlight color does not resize it

## Testing
- `composer lint-phpcs`


------
https://chatgpt.com/codex/tasks/task_e_68bc3eb73ba48332b90b80ffe4e4cb06