### PR TITLE
Fix note column width and center note buttons on small screens

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -114,6 +114,10 @@
         display: none;
     }
 
+    .politeia-hl-table td:nth-child(2) {
+        width: 80%;
+    }
+
     .politeia-hl-table tbody tr {
         display: block;
         text-align: center;
@@ -134,5 +138,11 @@
     .politeia-hl-table th + th,
     .politeia-hl-table td + td {
         border-left: none;
+    }
+
+    .politeia-hl-table .hl-note .hl-note-edit {
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
     }
 }


### PR DESCRIPTION
## Summary
- Ensure note column uses full width on screens below 767px
- Center "Add Note"/"Edit" buttons on narrow screens for better UI

## Testing
- `composer lint-phpcs`


------
https://chatgpt.com/codex/tasks/task_e_68bc417ac240833294302d138d3035e9