### PR TITLE
Refine mobile highlight layout and spacing

### DIFF
--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -43,7 +43,9 @@
 }
 
 .politeia-hl-table .hl-text .hl-highlight {
-    display: block;
+    display: flex;
+    flex: 1;
+    align-items: center;
     font-size: 18px;
     margin: 4px 0;
     padding: 12px;
@@ -57,11 +59,18 @@
 
 .politeia-hl-table .hl-text {
     border-radius: 9px 0 0 9px;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .politeia-hl-table .hl-note {
     border-left: none;
     border-radius: 0 9px 9px 0;
+}
+
+.politeia-hl-table .hl-text .hl-date-wrap {
+    margin-top: auto;
 }
 
 .politeia-hl-table .hl-note {

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -78,7 +78,6 @@
     font-size: 18px;
     position: relative;
     padding: 20px;
-    padding-bottom: 24px;
 }
 
 .politeia-hl-table .hl-note .note-display,

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -131,6 +131,7 @@
         border-top: none;
         border-left: 1px solid #000;
         border-radius: 0 0 9px 9px;
+        width: 80%;
     }
 
     .politeia-hl-filter {
@@ -158,7 +159,7 @@
 
     .politeia-hl-table tbody td {
         display: block;
-        width: 80%;
+        width: 100%;
         margin: auto;
         text-align: center;
     }

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -62,6 +62,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    padding: 20px;
 }
 
 .politeia-hl-table .hl-note {

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -31,6 +31,7 @@
 .politeia-hl-table th {
     cursor: pointer;
     background: none;
+    padding: 0;
 }
 
 

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -11,6 +11,12 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    border-bottom: 1px solid #000;
+}
+
+.politeia-hl-title {
+    font-weight: 900;
+    font-size: 28px;
 }
 
 .politeia-hl-table th,

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -12,6 +12,7 @@
     justify-content: space-between;
     align-items: center;
     border-bottom: 1px solid #000;
+    padding-bottom: 10px;
 }
 
 .politeia-hl-title {
@@ -155,6 +156,9 @@
     .politeia-hl-filter {
         flex-direction: column;
         align-items: center;
+        padding: 10px;
+        border-bottom: none;
+        width: 80%;
     }
 
     .politeia-hl-filter .politeia-hl-title {
@@ -164,6 +168,7 @@
     .politeia-hl-filter .hl-colors {
         margin-left: 0;
         justify-content: center;
+        margin-top: 10px;
     }
 
     .politeia-hl-table th {

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -20,10 +20,12 @@
     text-align: left;
 }
 
-/* Keep the note column width consistent across filters */
-.politeia-hl-table th:nth-child(2),
-.politeia-hl-table td:nth-child(2) {
-    width: 30%;
+/* Keep the note column width consistent across filters on larger screens */
+@media (min-width: 767px) {
+    .politeia-hl-table th:nth-child(2),
+    .politeia-hl-table td:nth-child(2) {
+        width: 30%;
+    }
 }
 
 .politeia-hl-table th {

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -131,7 +131,6 @@
         border-top: none;
         border-left: 1px solid #000;
         border-radius: 0 0 9px 9px;
-        width: 80%;
     }
 
     .politeia-hl-filter {
@@ -159,9 +158,14 @@
 
     .politeia-hl-table tbody td {
         display: block;
-        width: 100%;
+        width: 80%;
         margin: auto;
         text-align: center;
+    }
+
+    .politeia-hl-table th:nth-child(2),
+    .politeia-hl-table td:nth-child(2) {
+        width: 80%;
     }
 
     .politeia-hl-table th,

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -1,6 +1,6 @@
 .politeia-hl-table {
     width: 100%;
-    border-spacing: 10px 0;
+    border-spacing: 0 30px;
 }
 
 .politeia-hl-table tr {
@@ -51,7 +51,15 @@
 .politeia-hl-table .hl-text,
 .politeia-hl-table .hl-note {
     border: 1px solid #000;
-    border-radius: 9px;
+}
+
+.politeia-hl-table .hl-text {
+    border-radius: 9px 0 0 9px;
+}
+
+.politeia-hl-table .hl-note {
+    border-left: none;
+    border-radius: 0 9px 9px 0;
 }
 
 .politeia-hl-table .hl-note {
@@ -111,12 +119,36 @@
 }
 
 @media (max-width: 767px) {
-    .politeia-hl-table th:nth-child(2) {
-        display: none;
+    .politeia-hl-table {
+        border-spacing: 10px 0;
     }
 
-    .politeia-hl-table td:nth-child(2) {
-        width: 80%;
+    .politeia-hl-table .hl-text {
+        border-radius: 9px 9px 0 0;
+    }
+
+    .politeia-hl-table .hl-note {
+        border-top: none;
+        border-left: 1px solid #000;
+        border-radius: 0 0 9px 9px;
+    }
+
+    .politeia-hl-filter {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .politeia-hl-filter .politeia-hl-title {
+        text-align: center;
+    }
+
+    .politeia-hl-filter .hl-colors {
+        margin-left: 0;
+        justify-content: center;
+    }
+
+    .politeia-hl-table th {
+        display: none;
     }
 
     .politeia-hl-table tbody tr {

--- a/modules/highlight-table/assets/css/highlight-table.css
+++ b/modules/highlight-table/assets/css/highlight-table.css
@@ -76,6 +76,7 @@
 .politeia-hl-table .hl-note {
     font-size: 18px;
     position: relative;
+    padding: 20px;
     padding-bottom: 24px;
 }
 
@@ -174,6 +175,11 @@
         text-align: center;
     }
 
+    .politeia-hl-table .hl-text .hl-highlight {
+        justify-content: center;
+        text-align: center;
+    }
+
     .politeia-hl-table th:nth-child(2),
     .politeia-hl-table td:nth-child(2) {
         width: 80%;
@@ -192,5 +198,9 @@
         left: 50%;
         right: auto;
         transform: translateX(-50%);
+    }
+
+    .politeia-hl-table .hl-note textarea {
+        text-align: center;
     }
 }

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -40,6 +40,21 @@ document.addEventListener('DOMContentLoaded', function() {
     return div.innerHTML;
   }
 
+  function equalizeRowHeights() {
+    const isDesktop = window.innerWidth >= 767;
+    tbody.querySelectorAll('tr').forEach(function(row) {
+      const text = row.querySelector('.hl-text');
+      const note = row.querySelector('.hl-note');
+      if (!text || !note) return;
+      text.style.height = 'auto';
+      note.style.height = 'auto';
+      if (isDesktop) {
+        const h = Math.max(text.offsetHeight, note.offsetHeight);
+        text.style.height = note.style.height = h + 'px';
+      }
+    });
+  }
+
   function fetchHighlights(color) {
     const url = new URL(politeiaHLTable.restUrl, window.location.origin);
     if (color) {
@@ -72,6 +87,7 @@ document.addEventListener('DOMContentLoaded', function() {
               </td>`;
           tbody.appendChild(tr);
         });
+        equalizeRowHeights();
       });
   }
 
@@ -105,6 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const resize = () => {
         textarea.style.height = 'auto';
         textarea.style.height = textarea.scrollHeight + 'px';
+        equalizeRowHeights();
       };
       resize();
       textarea.addEventListener('input', resize);
@@ -129,11 +146,14 @@ document.addEventListener('DOMContentLoaded', function() {
         link.textContent = editLabel;
         delete cell.dataset.editing;
         cell.style.width = '';
+        equalizeRowHeights();
       } catch (err) {
         alert(errSave);
       }
     }
   });
+
+  window.addEventListener('resize', equalizeRowHeights);
 
   table.querySelectorAll('th[data-sort]').forEach(function(th) {
     th.addEventListener('click', function() {

--- a/modules/highlight-table/assets/js/highlight-table.js
+++ b/modules/highlight-table/assets/js/highlight-table.js
@@ -61,8 +61,10 @@ document.addEventListener('DOMContentLoaded', function() {
               <td class="hl-text">
                 <a class="hl-post-title" href="${escapeHtml(row.post_url)}">${escapeHtml(row.post_title)}</a>
                 <div class="hl-highlight">${escapeHtml(row.anchor_exact)}</div>
-                <hr class="hl-date-separator" />
-                <div class="hl-date" data-timestamp="${Math.floor(created.getTime() / 1000)}">${dateStr} ${timeStr}</div>
+                <div class="hl-date-wrap">
+                  <hr class="hl-date-separator" />
+                  <div class="hl-date" data-timestamp="${Math.floor(created.getTime() / 1000)}">${dateStr} ${timeStr}</div>
+                </div>
               </td>
               <td class="hl-note" data-id="${row.id}">
                 <div class="note-display">${escapeHtml(row.note)}</div>


### PR DESCRIPTION
## Summary
- apply note/text border radius adjustments only on small screens
- increase table row spacing on larger screens
- hide "Highlighted Text" and "Notes" headers on small screens
- join highlight text and note cells on desktop with squared inner corners and zero gap

## Testing
- `composer lint-phpcs`


------
https://chatgpt.com/codex/tasks/task_e_68bc53701c488332b84a1adbb6d2094d